### PR TITLE
fix CSV property handling for multilanguage and multivalue properties.

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -760,8 +760,8 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                             propertyValue.PropertyId = inheritedProperty.Id;
                         }
 
-                        //Try to split the one value to multiple values for Multivalue properties
-                        if (inheritedProperty.Multivalue)
+                        //Try to split the one value to multiple values for Multivalue/Multilanguage properties
+                        if (inheritedProperty.Multivalue || inheritedProperty.Multilanguage)
                         {
                             var parsedValues = new List<PropertyValue>();
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
@@ -90,7 +90,10 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                                  }
                                  else if (property.Multilanguage)
                                  {
-                                     propertyValues = property.Values.Select(v => string.Join(null, v.LanguageCode, CsvReaderExtension.InnerDelimiter, v.Value)).ToArray();
+                                     propertyValues = property
+                                         .Values
+                                         .Select(value => $"{value.LanguageCode}{CsvReaderExtension.InnerDelimiter}{value.Value}")
+                                         .ToArray();
                                  }
                                  else
                                  {
@@ -101,7 +104,7 @@ namespace VirtoCommerce.CatalogCsvImportModule.Data.Services
                                  }
                              }
 
-                             return string.Join(mappingCfg.Delimiter, propertyValues);
+                             return string.Join(CsvReaderExtension.Delimiter, propertyValues);
                          });
 
                     MemberMaps.Add(csvPropertyMap);


### PR DESCRIPTION
### 🐛 Bug Fix: Incorrect Handling of Multilanguage Property Values in CSV Export/Import

This PR addresses two bugs related to how multilanguage property values are exported and imported.

---

### 🔍 Problem Summary

1. **Incorrect delimiter used in export**

   * Currently, multilanguage values are joined with a comma (`,`), which breaks import parsing logic.
   * Example (current): `en-US__Value1,ar-EG__Value2`
   * Expected: `en-US__Value1;ar-EG__Value2`

2. **Import logic does not handle multilanguage-only properties**

   * The import assumes values need to be split only for `Multivalue` properties.
   * This causes incorrect parsing for properties that are `Multilanguage` but not `Multivalue`.

---

### ✅ Fix Summary

* **Export Logic:**

  * Ensures multilanguage values are joined using `CsvReaderExtension.Delimiter` (`;`) instead of a comma.
  * Formats multilanguage entries as:

    ```csharp
    $"{value.LanguageCode}{CsvReaderExtension.InnerDelimiter}{value.Value}"
    ```

* **Import Logic:**

  * Adjusted the condition to support multilanguage-only values:

    ```csharp
    if (inheritedProperty.Multivalue || inheritedProperty.Multilanguage)
    ```
  * This allows values like `en-US__Value1;ar-EG__Value2` to be correctly parsed into separate `PropertyValue` entries.

---

### 🔬 Tested Scenarios

* [x] Multilanguage-only properties
* [x] Multivalue + multilanguage properties
* [x] Dictionary properties remain unaffected
