### PR TITLE
VCST-3942: Export/import color code

### DIFF
--- a/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Core/VirtoCommerce.CatalogCsvImportModule.Core.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="ValueInjecter" Version="3.2.0" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.808.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.868.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.889.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.889.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.895.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.809.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvCatalogImporter.cs
@@ -250,7 +250,11 @@ public class CsvCatalogImporter(
                 }
             }
 
-            propertyValue.ValueId = dictionaryItem?.Id;
+            if (dictionaryItem != null)
+            {
+                propertyValue.ValueId = dictionaryItem.Id;
+                propertyValue.ColorCode = dictionaryItem.ColorCode;
+            }
         }
     }
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvProductMap.cs
@@ -91,7 +91,7 @@ public class CsvProductMap : ClassMap<CsvProduct>
                     (Property)new CsvProperty
                     {
                         Name = column,
-                        Values = x.Row.GetPropertiesByColumn(column).ToList(),
+                        Values = x.Row.GetValues(column).ToList(),
                     }).ToList());
             newPropMap.UsingExpression<ICollection<PropertyValue>>(null, null);
 

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvReaderExtension.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvReaderExtension.cs
@@ -197,6 +197,11 @@ public static class CsvReaderExtension
 
     private static string Escape(string input)
     {
+        if (input is null)
+        {
+            return null;
+        }
+
         if (!input.Contains(ValueDelimiter) &&
             !input.Contains(LanguageDelimiter) &&
             !input.Contains(ColorDelimiter) &&
@@ -212,7 +217,7 @@ public static class CsvReaderExtension
 
     private static string Unescape(string input)
     {
-        if (!input.StartsWith(EscapeString) || !input.EndsWith(EscapeString))
+        if (input is null || !input.StartsWith(EscapeString) || !input.EndsWith(EscapeString))
         {
             return input;
         }

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvReaderExtension.cs
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/Services/CsvReaderExtension.cs
@@ -147,26 +147,28 @@ public static class CsvReaderExtension
                 break;
             }
 
-            // Check for delimiter (only if not in escape)
-            if (!inEscape && remainingInput.StartsWith(delimiter))
+            if (!inEscape)
             {
-                result.Add(builder.ToString());
-                builder.Clear();
-                i += delimiter.Length;
-                continue;
-            }
+                // Check for escape start
+                if (remainingInput.StartsWith(EscapeString))
+                {
+                    builder.Append(EscapeString);
+                    i += EscapeString.Length;
+                    inEscape = true;
+                    continue;
+                }
 
-            // Check for escape start
-            if (!inEscape && remainingInput.StartsWith(EscapeString))
-            {
-                builder.Append(EscapeString);
-                i += EscapeString.Length;
-                inEscape = true;
-                continue;
+                // Check for delimiter
+                if (remainingInput.StartsWith(delimiter))
+                {
+                    result.Add(builder.ToString());
+                    builder.Clear();
+                    i += delimiter.Length;
+                    continue;
+                }
             }
-
             // Check for escape end
-            if (inEscape && remainingInput.StartsWith(EscapeString))
+            else if (remainingInput.StartsWith(EscapeString))
             {
                 if (remainingInput.StartsWith(doubleEscape))
                 {

--- a/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Data/VirtoCommerce.CatalogCsvImportModule.Data.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.868.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.889.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.818.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/VirtoCommerce.CatalogCsvImportModule.Web.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.821.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.889.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.895.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogCsvImportModule.Core\VirtoCommerce.CatalogCsvImportModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogCsvImportModule.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.812.0</version>
   <version-tag />
 
-  <platformVersion>3.889.0</platformVersion>
+  <platformVersion>3.895.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.808.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.868.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.889.0" />
     <dependency id="VirtoCommerce.Core" version="3.821.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.809.0" />

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/ImporterTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/ImporterTests.cs
@@ -126,6 +126,54 @@ public class ImporterTests
         Assert.Empty(progressInfo.Errors);
     }
 
+    [Theory]
+    [InlineData(",")]
+    [InlineData(";")]
+    public async Task DoImport_ColorMultivalueDictionary_ColorCodeIsTakenFromDictionary(string delimiter)
+    {
+        // Arrange
+        var csvProduct = GetCsvProductBase();
+
+        csvProduct.Properties = new List<Property>
+        {
+            new CsvProperty
+            {
+                Name = "Catalog Product Property 3 Color Multivalue Dictionary",
+                Values = new List<PropertyValue>
+                {
+                    new() { PropertyName = "Catalog Product Property 3 Color Multivalue Dictionary", Value = "Red" },
+                    new() { PropertyName = "Catalog Product Property 3 Color Multivalue Dictionary", Value = "Blue" },
+                },
+            },
+        };
+
+        var importer = GetImporter();
+
+        var progressInfo = new ExportImportProgressInfo();
+
+        // Act
+        await importer.DoImport([csvProduct], GetCsvImportInfo(delimiter), progressInfo, _ => { });
+
+        // Assert
+        Assert.Empty(progressInfo.Errors);
+        csvProduct.Properties.Should().HaveCount(1);
+
+        var property = csvProduct.Properties.First();
+        property.Values.Should().HaveCount(2);
+
+        var value1 = property.Values[0];
+        Assert.Equal("CatalogProductProperty_3_ColorMultivalueDictionary_1", value1.ValueId);
+        Assert.Equal(PropertyValueType.Color, value1.ValueType);
+        Assert.Equal("#ff0000", value1.ColorCode);
+        Assert.Equal("Red", value1.Alias);
+
+        var value2 = property.Values[1];
+        Assert.Equal("CatalogProductProperty_3_ColorMultivalueDictionary_3", value2.ValueId);
+        Assert.Equal(PropertyValueType.Color, value2.ValueType);
+        Assert.Equal("#0000ff", value2.ColorCode);
+        Assert.Equal("Blue", value2.Alias);
+    }
+
     [Fact]
     public async Task DoImport_NewProductMultivalueDictionaryProperties_PropertyValuesCreated()
     {
@@ -1788,6 +1836,16 @@ public class ImporterTests
                 },
                 new()
                 {
+                    Id =   "CatalogProductProperty_3_ColorMultivalueDictionary",
+                    Name = "Catalog Product Property 3 Color Multivalue Dictionary",
+                    CatalogId = catalogId,
+                    Dictionary = true,
+                    Multivalue = true,
+                    Type = PropertyType.Product,
+                    ValueType = PropertyValueType.Color,
+                },
+                new()
+                {
                     Name = "CatalogProductProperty_1_Multivalue",
                     Id = "CatalogProductProperty_1_Multivalue",
                     CatalogId = catalogId,
@@ -1872,6 +1930,10 @@ public class ImporterTests
             new() { Id = "CatalogProductProperty_2_MultivalueDictionary_1", PropertyId = "CatalogProductProperty_2_MultivalueDictionary", Alias = "1" },
             new() { Id = "CatalogProductProperty_2_MultivalueDictionary_2", PropertyId = "CatalogProductProperty_2_MultivalueDictionary", Alias = "2" },
             new() { Id = "CatalogProductProperty_2_MultivalueDictionary_3", PropertyId = "CatalogProductProperty_2_MultivalueDictionary", Alias = "3" },
+
+            new() { Id = "CatalogProductProperty_3_ColorMultivalueDictionary_1", PropertyId = "CatalogProductProperty_3_ColorMultivalueDictionary", Alias = "Red", ColorCode = "#ff0000" },
+            new() { Id = "CatalogProductProperty_3_ColorMultivalueDictionary_2", PropertyId = "CatalogProductProperty_3_ColorMultivalueDictionary", Alias = "Green", ColorCode = "#00ff00" },
+            new() { Id = "CatalogProductProperty_3_ColorMultivalueDictionary_3", PropertyId = "CatalogProductProperty_3_ColorMultivalueDictionary", Alias = "Blue", ColorCode = "#0000ff" },
 
             new() { Id = "CatalogProductProperty_1_Dictionary_1", PropertyId = "CatalogProductProperty_1_Dictionary", Alias = "1" },
             new() { Id = "CatalogProductProperty_1_Dictionary_2", PropertyId = "CatalogProductProperty_1_Dictionary", Alias = "2" },

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
@@ -425,6 +425,48 @@ public class MappingTests
         Assert.Equal("de-DE", value2.LanguageCode);
     }
 
+    [Theory]
+    [InlineData(",")]
+    [InlineData(";")]
+    public async Task CsvProductMapTest_ValueContainsDelimiters_DelimitersShouldBeEscaped(string delimiter)
+    {
+        // Arrange
+        var product = GetProduct();
+
+        product.Properties = new List<Property>
+        {
+            new()
+            {
+                Id = "property1",
+                Name = "Delimiters",
+                Values = new List<PropertyValue>
+                {
+                    new() { Value = "value1:1`2\"3,4;5__6|7", ColorCode = "color1:1`2\"3,4;5__6|7", LanguageCode = "language1:1`2\"3,4;5__6|7" },
+                    new() { Value = "value2:1`2\"3,4;5__6|7", ColorCode = "color2:1`2\"3,4;5__6|7", LanguageCode = "language2:1`2\"3,4;5__6|7" },
+                },
+            },
+        };
+
+        // Act
+        var importedCsvProduct = await ExportAndImportProduct(product, delimiter);
+
+        // Assert
+        importedCsvProduct.Properties.Should().HaveCount(1);
+
+        var property = importedCsvProduct.Properties.First();
+        property.Values.Should().HaveCount(2);
+
+        var value1 = property.Values[0];
+        Assert.Equal("value1:1`2\"3,4;5__6|7", value1.Value);
+        Assert.Equal("color1:1`2\"3,4;5__6|7", value1.ColorCode);
+        Assert.Equal("language1:1`2\"3,4;5__6|7", value1.LanguageCode);
+
+        var value2 = property.Values[1];
+        Assert.Equal("value2:1`2\"3,4;5__6|7", value2.Value);
+        Assert.Equal("color2:1`2\"3,4;5__6|7", value2.ColorCode);
+        Assert.Equal("language2:1`2\"3,4;5__6|7", value2.LanguageCode);
+    }
+
 
     // Support methods
     private static async Task<List<CsvProduct>> ReadCsvFile(string fileName, Action<CsvProductMappingConfiguration> configure = null)

--- a/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
+++ b/tests/VirtoCommerce.CatalogCsvImportModule.Test/MappingTests.cs
@@ -347,6 +347,85 @@ public class MappingTests
     }
 
 
+    [Theory]
+    [InlineData(",")]
+    [InlineData(";")]
+    public async Task CsvProductMapTest_Color_ColorCodeExported(string delimiter)
+    {
+        // Arrange
+        var product = GetProduct();
+
+        product.Properties = new List<Property>
+        {
+            new()
+            {
+                Id = "property1",
+                Name = "color_simple",
+                Values = new List<PropertyValue>
+                {
+                    new() { Value = "Red", ColorCode = "#ff0000", ValueType = PropertyValueType.Color },
+                },
+            },
+        };
+
+        // Act
+        var importedCsvProduct = await ExportAndImportProduct(product, delimiter);
+
+        // Assert
+        importedCsvProduct.Properties.Should().HaveCount(1);
+
+        var property = importedCsvProduct.Properties.First();
+        property.Values.Should().HaveCount(1);
+
+        var value = property.Values[0];
+        Assert.Equal("Red", value.Value);
+        Assert.Equal("#ff0000", value.ColorCode);
+    }
+
+    [Theory]
+    [InlineData(",")]
+    [InlineData(";")]
+    public async Task CsvProductMapTest_ColorMultilanguage_ColorCodeExported(string delimiter)
+    {
+        // Arrange
+        var product = GetProduct();
+
+        product.Properties = new List<Property>
+        {
+            new()
+            {
+                Id = "property1",
+                Name = "color_multilanguage",
+                Multilanguage = true,
+                Values = new List<PropertyValue>
+                {
+                    new() { Value = "Red", ColorCode = "#ff0000", LanguageCode = "en-US", ValueType = PropertyValueType.Color },
+                    new() { Value = "Rot", ColorCode = "#ff0000", LanguageCode = "de-DE", ValueType = PropertyValueType.Color },
+                },
+            },
+        };
+
+        // Act
+        var importedCsvProduct = await ExportAndImportProduct(product, delimiter);
+
+        // Assert
+        importedCsvProduct.Properties.Should().HaveCount(1);
+
+        var property = importedCsvProduct.Properties.First();
+        property.Values.Should().HaveCount(2);
+
+        var value1 = property.Values[0];
+        Assert.Equal("Red", value1.Value);
+        Assert.Equal("#ff0000", value1.ColorCode);
+        Assert.Equal("en-US", value1.LanguageCode);
+
+        var value2 = property.Values[1];
+        Assert.Equal("Rot", value2.Value);
+        Assert.Equal("#ff0000", value2.ColorCode);
+        Assert.Equal("de-DE", value2.LanguageCode);
+    }
+
+
     // Support methods
     private static async Task<List<CsvProduct>> ReadCsvFile(string fileName, Action<CsvProductMappingConfiguration> configure = null)
     {


### PR DESCRIPTION
## Description
When a property value has a color code, it should be added after the value and separated with `|` character:
```csv
Red|#ff0000
en-US__Red|#ff0000
```
This doesn't apply to dictionary properties, since all metadata is stored in the dictionary.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3942
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogCsvImportModule_3.812.0-pr-123-3ac7.zip